### PR TITLE
Fix material order. Add new material notation

### DIFF
--- a/io_export_cryblend/__init__.py
+++ b/io_export_cryblend/__init__.py
@@ -529,7 +529,7 @@ class AddMaterial(bpy.types.Operator):
                         index = len(get_materials_per_group(node_name)) + 1
                         #generate new material
                         material = bpy.data.materials.new(
-                            "{}__{}__{}__{}".format(
+                            "{}__{:03d}__{}__{}".format(
                             node_name.split(".")[0],
                             index, self.material_name, self.physics_type
                             )

--- a/io_export_cryblend/export.py
+++ b/io_export_cryblend/export.py
@@ -96,7 +96,7 @@ class CrytekDaeExporter:
         material_counter = {}
 
         for group in utils.get_export_nodes():
-            material_counter[group.name] = 0
+            material_counter[group.name] = 50
             for object in group.objects:
                 for slot in object.material_slots:
                     if slot.material is None:
@@ -104,26 +104,20 @@ class CrytekDaeExporter:
 
                     if slot.material not in materials:
 
+                        # backwards compatibility
                         nodename = utils.get_node_name(
                             group.name.replace("CryExportNode_", ""))
 
-                        if ("__" in slot.material.name):
-                            othernode = slot.material.name.split("__", 1)[0]
-                            if (othernode != nodename):
-                                materials[slot.material] = slot.material.name
-                                continue
+                        node, index, name, physics = utils.get_material_parts(
+                            nodename, slot.material.name)
 
-                        material_counter[group.name] += 1
-                        name, physics = utils.get_material_props(
-                            slot.material.name)
+                        # check if material has no position defined
+                        if index == 0:
+                            material_counter[group.name] += 1
+                            index = material_counter[group.name]
 
-                        materialname = "{}__{:03d}__{}__{}".format(
-                            nodename,
-                            material_counter[group.name],
-                            name,
-                            physics)
-
-                        materials[slot.material] = materialname
+                        materials[slot.material] = "{}__{:03d}__{}__{}".format(
+                            node, index, name, physics)
 
         return materials
 

--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -575,6 +575,51 @@ def has__material_physics(materialname):
         return False
 
 
+def get_material_parts(node, material):
+
+    VALID_PHYSICS = ("physDefault", "physProxyNoDraw", "physNoCollide",
+                     "physObstruct", "physNone")
+
+    parts = material.split("__")
+    count = len(parts)
+
+    group = node
+    index = 0
+    name = material
+    physics = "physDefault"
+
+    if count == 1:
+        # name
+        index = 0
+    elif count == 2:
+        # XXX__name or name__phys
+        if parts[1] not in VALID_PHYSICS:
+            # XXX__name
+            index = int(parts[0])
+            name = parts[1]
+        else:
+            # name__phys
+            name = parts[0]
+            physics = parts[1]
+    elif count == 3:
+        # XXX__name__phys
+        index = int(parts[0])
+        name = parts[1]
+        physics = parts[2]
+    elif count == 4:
+        # group__XXX__name__phys
+        group = parts[0]
+        index = int(parts[1])
+        name = parts[2]
+        physics = parts[3]
+
+    name = replace_invalid_rc_characters(name)
+    if physics not in VALID_PHYSICS:
+        physics = "physDefault"
+
+    return group, index, name, physics
+
+
 #------------------------------------------------------------------------------
 # Export Nodes:
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Materials were not properly ordered, ignoring current numeration.
New format material notations were added. Now the next formats are also accepted: 

- 001__mat,
- mat__physics
- 001__mat__physics