### PR TITLE
Polylist count warning

### DIFF
--- a/io_export_cryblend/export.py
+++ b/io_export_cryblend/export.py
@@ -606,6 +606,10 @@ class CrytekDaeExporter:
                 else:
                     normal += 1
 
+            if poly_count == 0:
+                matindex += 1
+                continue
+
             polylist = self.__doc.createElement('polylist')
             polylist.setAttribute('material', materialname)
             polylist.setAttribute('count', str(poly_count))


### PR DESCRIPTION
When a material is assigned to a mesh but it's not used in any face, the polylist count of vertices is zero. Resource Compiler shows a warning. This block shouldn't be written in the collada file to avoid this warning.