### PR TITLE
Armature data name fix

### DIFF
--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -723,12 +723,7 @@ def add_fakebones():
     if armature is None:
         return
 
-    try:
-        skeleton = bpy.data.armatures[armature.name]
-    except:
-        raise TypeError(
-            "Armature object name and object data name must " +
-            "be same! You may set it in properties or outliner editor.")
+    skeleton = armature.data
 
     skeleton.pose_position = 'REST'
     time.sleep(0.5)


### PR DESCRIPTION
Armature data (skeleton) name restriction has been removed.
Now, no needed armature and armature data (skeleton) name must be same.