### PR TITLE
Skeleton and Animation Fix

### DIFF
--- a/io_export_cryblend/__init__.py
+++ b/io_export_cryblend/__init__.py
@@ -1787,16 +1787,6 @@ class Export(bpy.types.Operator, ExportHelper):
         description="Create a base CDF file for character attachments.",
         default=False,
     )
-    include_ik = BoolProperty(
-        name="Include IK in Character",
-        description="Add IK to the physics skeleton upon export.",
-        default=False,
-    )
-    convert_space = BoolProperty(
-        name="Convert to Whitespaces",
-        description="Convert double underscores to whitespaces in skeleton.",
-        default=False,
-    )
     fix_weights = BoolProperty(
         name="Fix Weights",
         description="For use with .chr files. Generally a good idea.",
@@ -1850,8 +1840,6 @@ class Export(bpy.types.Operator, ExportHelper):
                 'do_textures',
                 'make_chrparams',
                 'make_cdf',
-                'include_ik',
-                'convert_space',
                 'fix_weights',
                 'average_planar',
                 'export_for_lumberyard',
@@ -1921,8 +1909,6 @@ class Export(bpy.types.Operator, ExportHelper):
         box.label("Character", icon="ARMATURE_DATA")
         box.prop(self, "make_chrparams")
         box.prop(self, "make_cdf")
-        box.prop(self, "include_ik")
-        box.prop(self, "convert_space")
 
         box = col.box()
         box.label("Corrective", icon="BRUSH_DATA")

--- a/io_export_cryblend/add.py
+++ b/io_export_cryblend/add.py
@@ -106,22 +106,22 @@ def get_bone_ik_max_min(pose_bone):
     xIK = yIK = zIK = ""
 
     if pose_bone.lock_ik_x:
-        xIK = 'xmax={!s}_'.format(0.0) + 'xmin={!s}_'.format(0.0)
+        xIK = '_xmax={!s}'.format(0.0) + '_xmin={!s}'.format(0.0)
     else:
-        xIK = 'xmax={!s}_'.format(math.degrees(pose_bone.ik_max_x)) \
-            + 'xmin={!s}_'.format(math.degrees(pose_bone.ik_min_x))
+        xIK = '_xmax={!s}'.format(math.degrees(pose_bone.ik_max_x)) \
+            + '_xmin={!s}'.format(math.degrees(pose_bone.ik_min_x))
 
     if pose_bone.lock_ik_y:
-        yIK = 'ymax={!s}_'.format(0.0) + 'ymin={!s}_'.format(0.0)
+        yIK = '_ymax={!s}'.format(0.0) + '_ymin={!s}'.format(0.0)
     else:
-        yIK = 'ymax={!s}_'.format(math.degrees(pose_bone.ik_max_y)) \
-            + 'ymin={!s}_'.format(math.degrees(pose_bone.ik_min_y))
+        yIK = '_ymax={!s}'.format(math.degrees(pose_bone.ik_max_y)) \
+            + '_ymin={!s}'.format(math.degrees(pose_bone.ik_min_y))
 
     if pose_bone.lock_ik_z:
-        zIK = 'zmax={!s}_'.format(0.0) + 'zmin={!s}_'.format(0.0)
+        zIK = '_zmax={!s}'.format(0.0) + '_zmin={!s}'.format(0.0)
     else:
-        zIK = 'zmax={!s}_'.format(math.degrees(pose_bone.ik_max_z)) \
-            + 'zmin={!s}_'.format(math.degrees(pose_bone.ik_min_z))
+        zIK = '_zmax={!s}'.format(math.degrees(pose_bone.ik_max_z)) \
+            + '_zmin={!s}'.format(math.degrees(pose_bone.ik_min_z))
 
     return xIK, yIK, zIK
 

--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -662,6 +662,13 @@ def get_node_type(node):
     return node_components[-1]
 
 
+def get_armature_node_name(object_):
+    ALLOWED_NODE_TYPES = ("cga", "anm", "chr", "skin", "i_caf")
+    for group in object_.users_group:
+        if get_node_type(group) in ALLOWED_NODE_TYPES:
+            return get_node_name(group)
+
+
 #------------------------------------------------------------------------------
 # Fakebones:
 #------------------------------------------------------------------------------
@@ -907,9 +914,10 @@ def apply_animation_scale(armature):
 #------------------------------------------------------------------------------
 
 def get_bone_geometry(bone_name):
-    for object_ in bpy.data.objects:
-        if is_bone_geometry(object_):
-            return object_
+    try:
+        return bpy.data.objects[bone_name + "_boneGeometry"]
+    except:
+        return None
 
 
 def is_bone_geometry(object_):


### PR DESCRIPTION
- Auto include IK, include IK checkbox has been removed.
- Auto convert double underscores to spaces, convert to spaces checkbox has been removed.

- Animation exporting has been fixed

- Now animation node name writes to dae instead of direct armature name. That is a base to export multiple animations logic.

- Skin node names writes to dae.

- Now skeleton and skin exporting works base on meshes instead of armatures. Armatures get direct skin parents. So now do not require add export nodes to armature. One just can add skin node to meshes.