### PR TITLE
Fix export node name

### DIFF
--- a/io_export_cryblend/export.py
+++ b/io_export_cryblend/export.py
@@ -1061,8 +1061,7 @@ class CrytekDaeExporter:
         for object_ in objects:
             if object_.type == "MESH" and not utils.is_fakebone(object_):
                 node = self.__doc.createElement("node")
-                node_name = utils.get_armature_node_name(object_)
-                node.setAttribute("id", node_name)
+                node.setAttribute("id", object_.name)
                 node.setIdAttribute("id")
 
                 self.__write_transforms(object_, node)


### PR DESCRIPTION
If node type is cgf then export node name is empty and fails if you have more than one geometry associated to this group. It reverts this change done in #177