### PR TITLE
Fix texture export in cycles

### DIFF
--- a/io_export_cryblend/export.py
+++ b/io_export_cryblend/export.py
@@ -182,7 +182,10 @@ class CrytekDaeExporter:
         library_images = self.__doc.createElement('library_images')
         parent_element.appendChild(library_images)
 
-        images = self.__get_image_textures_in_export_nodes()
+        if bpy.context.scene.render.engine == 'CYCLES':
+            images = self.__get_nodes_images_in_export_nodes()
+        else:
+            images = self.__get_image_textures_in_export_nodes()
 
         for image in images:
             image_element = self.__export_library_image(image)


### PR DESCRIPTION
Export images function was not checking if render is cycles so it was not finding any image to export. Fixes issue #182. Merge first pull request #183 to make this working.