### PR TITLE
Convert Texture to Game Folder

### DIFF
--- a/io_export_cryblend/__init__.py
+++ b/io_export_cryblend/__init__.py
@@ -138,23 +138,26 @@ to be able to export your textures as dds files.'''
         return ExportHelper.invoke(self, context, event)
 
 
-class SelectTexturesDirectory(bpy.types.Operator, PathSelectTemplate):
+class SelectGameDirectory(bpy.types.Operator, PathSelectTemplate):
     '''This path will be used to create relative path \
 for textures in .mtl file.'''
 
-    bl_label = "Select Textures Directory"
-    bl_idname = "file.select_texture_dir"
+    bl_label = "Select Game Directory"
+    bl_idname = "file.select_game_dir"
 
     filename_ext = ""
 
     def process(self, filepath):
-        Configuration.texture_dir = os.path.dirname(filepath)
-        cbPrint("Textures directory: {!r}.".format(
-            Configuration.texture_dir),
+        if not os.path.isdir(filepath):
+            raise exceptions.NoGameDirectorySelected
+
+        Configuration.game_dir = filepath
+        cbPrint("Game directory: {!r}.".format(
+            Configuration.game_dir),
             'debug')
 
     def invoke(self, context, event):
-        self.filepath = Configuration.texture_dir
+        self.filepath = Configuration.game_dir
 
         return ExportHelper.invoke(self, context, event)
 
@@ -1857,7 +1860,7 @@ class Export(bpy.types.Operator, ExportHelper):
             setattr(self, 'cryblend_version', VERSION)
             setattr(self, 'rc_path', Configuration.rc_path)
             setattr(self, 'texture_rc_path', Configuration.texture_rc_path)
-            setattr(self, 'texture_dir', Configuration.texture_dir)
+            setattr(self, 'game_dir', Configuration.game_dir)
 
     def execute(self, context):
         cbPrint(Configuration.rc_path, 'debug')
@@ -2129,7 +2132,7 @@ class ConfigurationsPanel(View3DPanel, Panel):
             "file.find_rc_for_texture_conversion",
             text="Find Texture RC")
         col.separator()
-        col.operator("file.select_texture_dir", text="Select Textures Folder")
+        col.operator("file.select_game_dir", text="Select Game Directory")
 
 class ExportPanel(View3DPanel, Panel):
     bl_label = "Export"
@@ -2386,8 +2389,8 @@ class ConfigurationsMenu(bpy.types.Menu):
             icon="SPACE2")
         layout.separator()
         layout.operator(
-            "file.select_texture_dir",
-            text="Select Textures Folder",
+            "file.select_game_dir",
+            text="Select Game Directory",
             icon="FILE_FOLDER")
 
 
@@ -2455,7 +2458,7 @@ def get_classes_to_register():
     classes = (
         FindRC,
         FindRCForTextureConversion,
-        SelectTexturesDirectory,
+        SelectGameDirectory,
         SaveCryBlendConfiguration,
 
         AddCryExportNode,

--- a/io_export_cryblend/configuration.py
+++ b/io_export_cryblend/configuration.py
@@ -29,7 +29,7 @@ class __Configuration:
     __CONFIG_FILEPATH = os.path.join(__CONFIG_PATH, __CONFIG_FILENAME)
     __DEFAULT_CONFIGURATION = {'RC_PATH': r'',
                                'TEXTURE_RC_PATH': r'',
-                               'TEXTURE_DIR': r''}
+                               'GAME_DIR': r''}
 
     def __init__(self):
         self.__CONFIG = self.__load({})
@@ -54,12 +54,12 @@ class __Configuration:
         self.__CONFIG['TEXTURE_RC_PATH'] = value
 
     @property
-    def texture_dir(self):
-        return self.__CONFIG['TEXTURE_DIR']
+    def game_dir(self):
+        return self.__CONFIG['GAME_DIR']
 
-    @texture_dir.setter
-    def texture_dir(self, value):
-        self.__CONFIG['TEXTURE_DIR'] = value
+    @game_dir.setter
+    def game_dir(self, value):
+        self.__CONFIG['GAME_DIR'] = value
 
     def configured(self):
         path = self.__CONFIG['RC_PATH']

--- a/io_export_cryblend/exceptions.py
+++ b/io_export_cryblend/exceptions.py
@@ -55,3 +55,11 @@ Usually located in 'CryEngine\\Bin32\\rc\\rc.exe'
 """
 
         CryBlendException.__init__(self, message)
+
+
+class NoGameDirectorySelected(CryBlendException):
+
+    def __init__(self):
+        message = "Please select a Game Directory!"
+
+        CryBlendException.__init__(self, message)

--- a/io_export_cryblend/export.py
+++ b/io_export_cryblend/export.py
@@ -195,10 +195,8 @@ class CrytekDaeExporter:
             self.__convert_images_to_dds(images)
 
     def __export_library_image(self, image):
-        image_name = utils.get_filename(image.filepath)
-        dds_path = utils.build_path(
-            self.__config.texture_dir, image_name, ".dds")
-        image_path = utils.trim_path_to(dds_path, "Objects")
+        image_path = utils.get_image_path_for_game(image,
+                                        self.__config.game_dir)
 
         image_element = self.__doc.createElement('image')
         image_element.setAttribute('id', image.name)

--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -533,6 +533,17 @@ def is_valid_cycles_texture_node(node):
     return False
 
 
+def get_image_path_for_game(image, game_dir):
+    if not game_dir or not os.path.isdir(game_dir):
+        raise exceptions.NoGameDirectorySelected
+
+    image_path = os.path.normpath(bpy.path.abspath(image.filepath))
+    image_path = get_path_with_new_extension(image_path, "dds")
+    image_path = os.path.relpath(image_path, game_dir)
+
+    return image_path
+
+
 #------------------------------------------------------------------------------
 # Materials:
 #------------------------------------------------------------------------------


### PR DESCRIPTION
- Texture exporting fixed.
- Now, textures can be located anywhere in game directory.
- __Select Textures Directory__ tool changed to __Select Game Directory__