### PR TITLE
Fix numbered materials

### DIFF
--- a/io_export_cryblend/export.py
+++ b/io_export_cryblend/export.py
@@ -116,7 +116,17 @@ class CrytekDaeExporter:
                         materials[slot.material] = "{}__{:02d}__{}__{}".format(
                             node, index, name, physics)
 
-        return materials
+        materials_reorderer = {}
+        counter = {}
+        for key in materials.keys():
+            parts = materials[key].split("__")
+            if parts[0] not in counter:
+                counter[parts[0]] = 0
+            counter[parts[0]] += 1
+            materials_reorderer[key] = "{}__{:02d}__{}__{}".format(
+                parts[0], counter[parts[0]], parts[2], parts[3])
+
+        return materials_reorderer
 
     def __get_materials_for_object(self, object_):
         materials = OrderedDict()


### PR DESCRIPTION
In some cases rc.exe cannot manage well the materials if they are not stating from counter 1 and numbers are not correlaitve. This patch renumber the materials. The final material list is not ordered but properly numbered, which solved the problem.
