### PR TITLE
Export Multiple Animation #201

### DIFF
--- a/io_export_cryblend/__init__.py
+++ b/io_export_cryblend/__init__.py
@@ -59,7 +59,7 @@ if "bpy" in locals():
     imp.reload(desc)
 else:
     import bpy
-    from io_export_cryblend import add, export, exceptions, utils, desc
+    from io_export_cryblend import add, export, export_animations, exceptions, utils, desc
 
 from bpy.props import BoolProperty, EnumProperty, FloatVectorProperty, \
     FloatProperty, IntProperty, StringProperty, BoolVectorProperty
@@ -230,6 +230,75 @@ class AddCryExportNode(bpy.types.Operator):
             self.report(
                 {'ERROR'},
                 "Select one or more objects in OBJECT mode.")
+            return {'FINISHED'}
+
+        return context.window_manager.invoke_props_dialog(self)
+
+
+class AddCryAnimationNode(bpy.types.Operator):
+    '''Add selected objects to an existing or new CryExportNode'''
+    bl_label = "Add Animation Node"
+    bl_idname = "object.add_cry_animation_node"
+    bl_options = {"REGISTER", "UNDO"}
+
+    node_name = StringProperty(name="Animation Name")
+    node_start = IntProperty(name="Start Frame")
+    node_end = IntProperty(name="End Frame")
+    is_use_markers = BoolProperty(name="Use Markers")
+    start_m_name = StringProperty(name="Marker Start Name")
+    end_m_name = StringProperty(name="Marker End Name")
+    
+    def __init__(self):
+        self.node_start = bpy.context.scene.frame_start
+        self.node_end = bpy.context.scene.frame_end
+
+        return None
+
+    def execute(self, context):
+        skeleton = bpy.context.active_object
+        if skeleton and skeleton.type == 'ARMATURE':
+            node_start = None
+            node_end = None
+            
+            start_name = "{}_Start".format(self.node_name)
+            end_name = "{}_End".format(self.node_name)
+        
+            if self.is_use_markers:
+                node_start = self.start_m_name
+                node_end = self.end_m_name
+                
+                tm = bpy.context.scene.timeline_markers
+                if tm.find(self.start_m_name) == -1:
+                    tm.new(name=self.start_m_name, frame=self.node_start)
+                if tm.find(self.end_m_name) == -1:
+                    tm.new(name=self.end_m_name, frame=self.node_end)
+            else:
+                node_start = self.node_start
+                node_end = self.node_end
+
+            skeleton[start_name] = node_start
+            skeleton[end_name] = node_end
+            
+            node_name = "{}.i_caf".format(self.node_name)
+            group = bpy.data.groups.get(node_name)
+            if group is None:
+                bpy.ops.group.create(name=node_name)
+            else:
+                for object in bpy.context.selected_objects:
+                    if object.name not in group.objects:
+                        group.objects.link(object)
+
+            message = "Adding Export Node"
+        else:
+            message = "There is no a active armature! Please select a armature."
+
+        self.report({"INFO"}, message)
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        skeleton = bpy.context.active_object
+        if not skeleton or skeleton.type != 'ARMATURE':
+            self.report({'ERROR'}, "Please select and active a armature.")
             return {'FINISHED'}
 
         return context.window_manager.invoke_props_dialog(self)
@@ -1952,6 +2021,114 @@ class Export(bpy.types.Operator, ExportHelper):
         box.prop(self, "run_in_profiler")
 
 
+class ExportAnimations(bpy.types.Operator, ExportHelper):
+    '''Export animations to CryEngine'''
+    bl_label = "Export Animations"
+    bl_idname = "scene.export_animations"
+    filename_ext = ".dae"
+    filter_glob = StringProperty(default="*.dae", options={'HIDDEN'})
+
+    do_not_merge = BoolProperty(
+        name="Do Not Merge Nodes",
+        description="Generally a good idea.",
+        default=True,
+    )
+    export_for_lumberyard = BoolProperty(
+        name="Export for LumberYard",
+        description="Export for LumberYard engine instead of CryEngine.",
+        default=False,
+    )
+    disable_rc = BoolProperty(
+        name="Disable RC",
+        description="Do not run the resource compiler.",
+        default=False,
+    )
+    save_dae = BoolProperty(
+        name="Save DAE File",
+        description="Save the DAE file for developing purposes.",
+        default=False,
+    )
+    run_in_profiler = BoolProperty(
+        name="Profile CryBlend",
+        description="Select only if you want to profile CryBlend.",
+        default=False,
+    )
+    do_materials = False
+    make_layer = False
+
+    class Config:
+
+        def __init__(self, config):
+            attributes = (
+                'filepath',
+                'do_not_merge',
+                'do_materials',
+                'export_for_lumberyard',
+                'make_layer',
+                'disable_rc',
+                'save_dae',
+                'run_in_profiler'
+            )
+
+            for attribute in attributes:
+                setattr(self, attribute, getattr(config, attribute))
+
+            setattr(self, 'cryblend_version', VERSION)
+            setattr(self, 'rc_path', Configuration.rc_path)
+            setattr(self, 'texture_rc_path', Configuration.texture_rc_path)
+            setattr(self, 'game_dir', Configuration.game_dir)
+
+    def execute(self, context):
+        cbPrint(Configuration.rc_path, 'debug')
+        try:
+            config = ExportAnimations.Config(config=self)
+
+            if self.run_in_profiler:
+                import cProfile
+                cProfile.runctx('export_animations.save(config)', {},
+                                {'export_animations': export_animations, 'config': config})
+            else:
+                export_animations.save(config)
+
+            self.filepath = '//'
+
+        except exceptions.CryBlendException as exception:
+            cbPrint(exception.what(), 'error')
+            bpy.ops.screen.display_error(
+                'INVOKE_DEFAULT', message=exception.what())
+
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        if not Configuration.configured():
+            self.report({'ERROR'}, "No RC found.")
+            return {'FINISHED'}
+
+        if not utils.get_export_nodes():
+            self.report({'ERROR'}, "No export nodes found.")
+            return {'FINISHED'}
+
+        return ExportHelper.invoke(self, context, event)
+
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+
+        box = col.box()
+        box.label("General", icon="WORLD")
+        box.prop(self, "do_not_merge")
+
+        box = col.box()
+        box.label("LumberYard", icon="GAME")
+        box.prop(self, "export_for_lumberyard")
+
+        box = col.box()
+        box.label("Developer Tools", icon="MODIFIER")
+        box.prop(self, "disable_rc")
+        box.prop(self, "save_dae")
+        box.prop(self, "run_in_profiler")
+
+
 class ErrorHandler(bpy.types.Operator):
     bl_label = "Error:"
     bl_idname = "screen.display_error"
@@ -2013,6 +2190,7 @@ class ExportUtilitiesPanel(View3DPanel, Panel):
         col.separator()
         row = col.row(align=True)
         row.operator("object.add_cry_export_node", text="Add Export Node")
+        row.operator("object.add_cry_animation_node", text="Add Animation Node")
         col.operator(
             "object.selected_to_cry_export_nodes",
             text="Export Nodes from Objects")
@@ -2166,6 +2344,10 @@ class ExportPanel(View3DPanel, Panel):
         col.label("Export", icon="GAME")
         col.separator()
         col.operator("scene.export_to_game", text="Export to Game")
+        col.separator()
+        col.label("Export Animations", icon="GAME")
+        col.separator()
+        col.operator("scene.export_animations", text="Export Animations")
 
 #------------------------------------------------------------------------------
 # CryBlend Menu:
@@ -2191,8 +2373,13 @@ class CryBlendMainMenu(bpy.types.Menu):
             text="Add Export Node",
             icon="GROUP")
         layout.operator(
+            "object.add_cry_animation_node",
+            text="Add Animation Node",
+            icon="PREVIEW_RANGE")
+        layout.operator(
             "object.selected_to_cry_export_nodes",
-            text="Export Nodes from Objects")
+            text="Export Nodes from Objects",
+            icon="GROUP")
         layout.separator()
         layout.operator(
             "object.apply_transforms",
@@ -2217,6 +2404,8 @@ class CryBlendMainMenu(bpy.types.Menu):
         layout.separator()
         layout.separator()
         layout.operator("scene.export_to_game", icon="GAME")
+        layout.separator()
+        layout.operator("scene.export_animations", icon="RENDER_ANIMATION")
 
 
 class AddPhysicsProxyMenu(bpy.types.Menu):
@@ -2518,6 +2707,7 @@ def get_classes_to_register():
         SaveCryBlendConfiguration,
 
         AddCryExportNode,
+        AddCryAnimationNode,
         SelectedToCryExportNodes,
         AddMaterial,
         SetMaterialNames,
@@ -2558,6 +2748,7 @@ def get_classes_to_register():
         ApplyAnimationScale,
 
         Export,
+        ExportAnimations,
         ErrorHandler,
 
         ExportUtilitiesPanel,

--- a/io_export_cryblend/exceptions.py
+++ b/io_export_cryblend/exceptions.py
@@ -63,3 +63,11 @@ class NoGameDirectorySelected(CryBlendException):
         message = "Please select a Game Directory!"
 
         CryBlendException.__init__(self, message)
+
+
+class MarkersNotFound(CryBlendException):
+
+    def __init__(self):
+        message = "Start or end marker is less!"
+
+        CryBlendException.__init__(self, message)

--- a/io_export_cryblend/export_animations.py
+++ b/io_export_cryblend/export_animations.py
@@ -1,0 +1,352 @@
+#------------------------------------------------------------------------------
+# Name:        export_animations.py
+# Purpose:     Animation exporter to CryEngine
+#
+# Author:      Özkan Afacan,
+#              Angelo J. Miner, Daniel White, David Marcelis, Duo Oratar,
+#              Mikołaj Milej, Oscar Martin Garcia
+#
+# Created:     13/06/2016
+# Copyright:   (c) Özkan Afacan 2016
+# License:     GPLv2+
+#------------------------------------------------------------------------------
+
+
+if "bpy" in locals():
+    import imp
+    imp.reload(utils)
+    imp.reload(exceptions)
+else:
+    import bpy
+    from io_export_cryblend import export, utils, add, exceptions
+
+from io_export_cryblend.rc import RCInstance
+from io_export_cryblend.outpipe import cbPrint
+
+from xml.dom.minidom import Document, Element, parse, parseString
+import xml.dom.minidom
+import os
+
+
+AXES = {
+    'X': 0,
+    'Y': 1,
+    'Z': 2,
+}
+
+
+class CrytekDaeAnimationExporter(export.CrytekDaeExporter):
+
+    def __init__(self, config):
+        self._config = config
+        self._doc = Document()
+
+    def export(self):
+        self._prepare_for_export()
+
+        root_element = self._doc.createElement('collada')
+        root_element.setAttribute(
+            "xmlns", "http://www.collada.org/2005/11/COLLADASchema")
+        root_element.setAttribute("version", "1.4.1")
+        self._doc.appendChild(root_element)
+        self._create_file_header(root_element)
+        
+        libanmcl = self._doc.createElement("library_animation_clips")
+        libanm = self._doc.createElement("library_animations")
+        root_element.appendChild(libanmcl)
+        root_element.appendChild(libanm)
+        
+        lib_visual_scene = self._doc.createElement("library_visual_scenes")
+        visual_scene = self._doc.createElement("visual_scene")
+        visual_scene.setAttribute("id", "scene")
+        visual_scene.setAttribute("name", "scene")
+        lib_visual_scene.appendChild(visual_scene)
+        root_element.appendChild(lib_visual_scene)
+       
+        ALLOWED_NODE_TYPES = ("cga", "anm", "i_caf")
+        for group in utils.get_export_nodes():
+
+            node_type = utils.get_node_type(group)
+            node_name = utils.get_node_name(group)
+
+            object_ = None
+
+            if node_type == 'i_caf':
+                object_ = utils.get_armature_from_node(group)
+            elif node_type == 'anm':
+                object_ = group.objects[0]
+
+            frame_start, frame_end = utils.get_animation_node_range(object_, node_name)
+            bpy.context.scene.frame_start = frame_start
+            bpy.context.scene.frame_end = frame_end
+
+            if node_type == 'i_caf':
+                utils.add_fakebones(group)
+            try:
+                self._export_library_animation_clips_and_animations(libanmcl, libanm, group)
+                self._export_library_visual_scenes(visual_scene, group)
+            except RuntimeError:
+                pass
+            finally:
+                if node_type == 'i_caf':
+                    utils.remove_fakebones()
+
+        self._export_scene(root_element)
+
+        converter = RCInstance(self._config)
+        converter.convert_dae(self._doc)
+
+    def _prepare_for_export(self):
+        utils.clean_file()
+
+
+# -----------------------------------------------------------------------------
+# Library Animations and Clips: --> Animations, F-Curves
+# -----------------------------------------------------------------------------
+
+    def _export_library_animation_clips_and_animations(self, libanmcl, libanm, group):
+
+        scene = bpy.context.scene
+
+        animation_clip = self._doc.createElement("animation_clip")
+        node_name = utils.get_node_name(group)
+        animation_clip.setAttribute("id", "{!s}-{!s}".format(node_name, node_name))
+        animation_clip.setAttribute("start", "{:f}".format(
+            utils.frame_to_time(scene.frame_start)))
+        animation_clip.setAttribute("end", "{:f}".format(
+                utils.frame_to_time(scene.frame_end)))
+        is_animation = False
+
+        for object_ in bpy.context.selected_objects:
+            if (object_.type != 'ARMATURE' and object_.animation_data and
+                    object_.animation_data.action):
+
+                is_animation = True
+
+                props_name = self._create_props_bone_name(object_, node_name)
+                bone_name = "{!s}{!s}".format(object_.name, props_name)
+
+                for axis in iter(AXES):
+                    animation = self._get_animation_location(
+                        object_, bone_name, axis, node_name)
+                    if animation is not None:
+                        libanm.appendChild(animation)
+
+                for axis in iter(AXES):
+                    animation = self._get_animation_rotation(
+                        object_, bone_name, axis, node_name)
+                    if animation is not None:
+                        libanm.appendChild(animation)
+
+                self._export_instance_animation_parameters(
+                    object_, animation_clip, node_name)
+
+        if is_animation:
+            libanmcl.appendChild(animation_clip)
+
+    def _export_instance_animation_parameters(self, object_, animation_clip, node_name):
+        location_exists = rotation_exists = False
+        for curve in object_.animation_data.action.fcurves:
+            for axis in iter(AXES):
+                if curve.array_index == AXES[axis]:
+                    if curve.data_path == "location":
+                        location_exists = True
+                    if curve.data_path == "rotation_euler":
+                        rotation_exists = True
+                    if location_exists and rotation_exists:
+                        break
+
+        if location_exists:
+            self._export_instance_parameter(
+                object_, animation_clip, "location", node_name)
+        if rotation_exists:
+            self._export_instance_parameter(
+                object_, animation_clip, "rotation_euler", node_name)
+
+    def _export_instance_parameter(self, object_, animation_clip, parameter, node_name):
+        for axis in iter(AXES):
+            inst = self._doc.createElement("instance_animation")
+            inst.setAttribute(
+                "url", "#{!s}-{!s}-{!s}_{!s}_{!s}".format(
+                    node_name, node_name, object_.name, parameter, axis))
+            animation_clip.appendChild(inst)
+
+    def _get_animation_location(self, object_, bone_name, axis, node_name):
+        attribute_type = "location"
+        multiplier = 1
+        target = "{!s}{!s}{!s}".format(bone_name, "/translation.", axis)
+
+        animation_element = self._get_animation_attribute(object_,
+                                                           axis,
+                                                           attribute_type,
+                                                           multiplier,
+                                                           target,
+                                                           node_name)
+        return animation_element
+
+    def _get_animation_rotation(self, object_, bone_name, axis, node_name):
+        attribute_type = "rotation_euler"
+        multiplier = utils.to_degrees
+        target = "{!s}{!s}{!s}{!s}".format(bone_name,
+                                           "/rotation_",
+                                           axis,
+                                           ".ANGLE")
+
+        animation_element = self._get_animation_attribute(object_,
+                                                           axis,
+                                                           attribute_type,
+                                                           multiplier,
+                                                           target,
+                                                           node_name)
+        return animation_element
+
+    def _get_animation_attribute(self,
+                                  object_,
+                                  axis,
+                                  attribute_type,
+                                  multiplier,
+                                  target,
+                                  node_name):
+        id_prefix = "{!s}-{!s}-{!s}_{!s}_{!s}".format(node_name, node_name,
+                                           object_.name, attribute_type, axis)
+        source_prefix = "#{!s}".format(id_prefix)
+
+        for curve in object_.animation_data.action.fcurves:
+            if (curve.data_path ==
+                    attribute_type and curve.array_index == AXES[axis]):
+                keyframe_points = curve.keyframe_points
+                sources = {
+                    "input": [],
+                    "output": [],
+                    "interpolation": [],
+                    "intangent": [],
+                    "outangent": []
+                }
+                for keyframe_point in keyframe_points:
+                    khlx = keyframe_point.handle_left[0]
+                    khly = keyframe_point.handle_left[1]
+                    khrx = keyframe_point.handle_right[0]
+                    khry = keyframe_point.handle_right[1]
+                    frame, value = keyframe_point.co
+
+                    sources["input"].append(utils.frame_to_time(frame))
+                    sources["output"].append(value * multiplier)
+                    sources["interpolation"].append(
+                        keyframe_point.interpolation)
+                    sources["intangent"].extend(
+                        [utils.frame_to_time(khlx), khly])
+                    sources["outangent"].extend(
+                        [utils.frame_to_time(khrx), khry])
+
+                animation_element = self._doc.createElement("animation")
+                animation_element.setAttribute("id", id_prefix)
+
+                for type_, data in sources.items():
+                    anim_node = self._create_animation_node(
+                        type_, data, id_prefix)
+                    animation_element.appendChild(anim_node)
+
+                sampler = self._create_sampler(id_prefix, source_prefix)
+                channel = self._doc.createElement("channel")
+                channel.setAttribute(
+                    "source", "{!s}-sampler".format(source_prefix))
+                channel.setAttribute("target", target)
+
+                animation_element.appendChild(sampler)
+                animation_element.appendChild(channel)
+
+                return animation_element
+
+    def _create_animation_node(self, type_, data, id_prefix):
+        id_ = "{!s}-{!s}".format(id_prefix, type_)
+        type_map = {
+            "input": ["float", ["TIME"]],
+            "output": ["float", ["VALUE"]],
+            "intangent": ["float", "XY"],
+            "outangent": ["float", "XY"],
+            "interpolation": ["name", ["INTERPOLATION"]]
+        }
+
+        source = utils.write_source(
+            id_, type_map[type_][0], data, type_map[type_][1])
+
+        return source
+
+    def _create_sampler(self, id_prefix, source_prefix):
+        sampler = self._doc.createElement("sampler")
+        sampler.setAttribute("id", "{!s}-sampler".format(id_prefix))
+
+        input = self._doc.createElement("input")
+        input.setAttribute("semantic", "INPUT")
+        input.setAttribute("source", "{!s}-input".format(source_prefix))
+        output = self._doc.createElement("input")
+        output.setAttribute("semantic", "OUTPUT")
+        output.setAttribute("source", "{!s}-output".format(source_prefix))
+        interpolation = self._doc.createElement("input")
+        interpolation.setAttribute("semantic", "INTERPOLATION")
+        interpolation.setAttribute(
+            "source", "{!s}-interpolation".format(source_prefix))
+        intangent = self._doc.createElement("input")
+        intangent.setAttribute("semantic", "IN_TANGENT")
+        intangent.setAttribute(
+            "source", "{!s}-intangent".format(source_prefix))
+        outangent = self._doc.createElement("input")
+        outangent.setAttribute("semantic", "OUT_TANGENT")
+        outangent.setAttribute(
+            "source", "{!s}-outangent".format(source_prefix))
+
+        sampler.appendChild(input)
+        sampler.appendChild(output)
+        sampler.appendChild(interpolation)
+        sampler.appendChild(intangent)
+        sampler.appendChild(outangent)
+
+        return sampler
+
+# ---------------------------------------------------------------------
+# Library Visual Scene: --> Skeleton and _Phys bones, Bone
+#       Transformations, and Instance URL (_boneGeometry) and extras.
+# ---------------------------------------------------------------------
+
+    def _export_library_visual_scenes(self, visual_scene, group):
+
+        if utils.get_export_nodes():
+            if utils.are_duplicate_nodes():
+                message = "Duplicate Node Names"
+                bpy.ops.screen.display_error('INVOKE_DEFAULT', message=message)
+
+            self._write_export_node(group, visual_scene)
+        else:
+            pass  # TODO: Handle No Export Nodes Error
+
+
+# -------------------------------------------------------------------
+
+
+def save(config):
+    # prevent wasting time for exporting if RC was not found
+    if not config.disable_rc and not os.path.isfile(config.rc_path):
+        raise exceptions.NoRcSelectedException
+
+    exporter = CrytekDaeAnimationExporter(config)
+    exporter.export()
+
+
+def register():
+    bpy.utils.register_class(CrytekDaeAnimationExporter)
+
+    bpy.utils.register_class(TriangulateMeError)
+    bpy.utils.register_class(Error)
+
+
+def unregister():
+    bpy.utils.unregister_class(CrytekDaeAnimationExporter)
+    bpy.utils.unregister_class(TriangulateMeError)
+    bpy.utils.unregister_class(Error)
+
+
+if __name__ == "__main__":
+    register()
+
+    # test call
+    bpy.ops.export_mesh.crytekdae('INVOKE_DEFAULT')


### PR DESCRIPTION
__Multiple animation exporting__ #201

__Aims:__

- New export_animation.py file;
Object and animation slightly (or more) are different procedures for exporting. I decided that we must take care of its separately to improve development and debugging performance. Like Maya.

- New Export Animations menu item below or top of Export to Game menu item:
With that way a scene can include chr, skin and i_caf nodes together. User may export them separately without any confusion.

- New Add Animation Node menu item below of Add Export Node menu item.

-----------------------------------

__Multiple animation procedure:__
__I aims two optionally way to decide animations:__

1 - Armature Custom properties that hold start and end of animation.
2 - Markers those hold start and end of animation. Also that have advantage to change a animation start or end position very quickly.