### PR TITLE
Changed Visual Scene for Animations

### DIFF
--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -703,7 +703,14 @@ def add_fakebones(group = None):
     '''Add helpers to track bone transforms.'''
     scene = bpy.context.scene
     remove_unused_meshes()
-    armature = get_armature()
+
+    if group:
+        for object_ in group.objects:
+            if object_.type == 'ARMATURE':
+                armature = object_
+    else:
+        armature = get_armature()
+
     if armature is None:
         return
 


### PR DESCRIPTION
-  _write_export_node function has been overridden.
- _write_visual_scene_node function has been overridden.

for CrytekDaeAnimationExporter class.

- Now, i_caf animation nodes directly relate to armatures.
- Now, armatures not need a primitive mesh to export animation.
- Now, i_caf animation nodes must be added to armatures. Not required to add to primitive mesh.