### PR TITLE
New Shading System

### DIFF
--- a/io_export_cryblend/__init__.py
+++ b/io_export_cryblend/__init__.py
@@ -1909,11 +1909,6 @@ class Export(bpy.types.Operator, ExportHelper):
         description="For use with .chr files. Generally a good idea.",
         default=False,
     )
-    average_planar = BoolProperty(
-        name="Average Planar Face Normals",
-        description="Align face normals within 1 degree of each other.",
-        default=False,
-    )
     export_for_lumberyard = BoolProperty(
         name="Export for LumberYard",
         description="Export for LumberYard engine instead of CryEngine.",
@@ -1958,7 +1953,6 @@ class Export(bpy.types.Operator, ExportHelper):
                 'make_chrparams',
                 'make_cdf',
                 'fix_weights',
-                'average_planar',
                 'export_for_lumberyard',
                 'make_layer',
                 'disable_rc',
@@ -2030,7 +2024,6 @@ class Export(bpy.types.Operator, ExportHelper):
         box = col.box()
         box.label("Corrective", icon="BRUSH_DATA")
         box.prop(self, "fix_weights")
-        box.prop(self, "average_planar")
 
         box = col.box()
         box.label("LumberYard", icon="GAME")

--- a/io_export_cryblend/export_animations.py
+++ b/io_export_cryblend/export_animations.py
@@ -396,6 +396,36 @@ class CrytekDaeAnimationExporter(export.CrytekDaeExporter):
         return parent_node
 
 
+    def _create_cryengine_extra(self, node):
+        extra = self._doc.createElement("extra")
+        technique = self._doc.createElement("technique")
+        technique.setAttribute("profile", "CryEngine")
+        properties = self._doc.createElement("properties")
+
+        node_type = utils.get_node_type(node)
+        prop = self._doc.createTextNode("fileType={}".format(node_type))
+        properties.appendChild(prop)
+
+        prop = self._doc.createTextNode("CustomExportPath=")
+        properties.appendChild(prop)
+        else:
+            if not node.rna_type.id_data.items():
+                return
+        for prop in node.rna_type.id_data.items():
+            self._create_user_defined_property(prop, properties)
+
+        technique.appendChild(properties)
+
+        if (node.name[:6] == "_joint"):
+            helper = self._create_helper_joint(node)
+            technique.appendChild(helper)
+
+        extra.appendChild(technique)
+        extra.appendChild(self._create_xsi_profile(node))
+
+        return extra
+
+
 # -------------------------------------------------------------------
 
 


### PR DESCRIPTION
__New shading system__

- [x] Improve library geometry codes.
- [x] New geometry name and subnodes name convention with more compatible DAE file.
- [x] Discard Average Planer Face Normals checkbox and property which not needed anymore.

__What you see in Cryblend what you get in CryEngine for shading__
With that issue, one do not need anymore apply Edge Split modifier before exporting objects.
What your object shading is in Blender, you get object shading is in CryEngine in all circumstances.

- [x] Support edge split modifiers without apply it.
- [x] Support both of face and edge (with sharp edges) smooth or flat shading.
- [x] Support auto smooth with angle from object data panel.
- [x] Support Display modifier in viewport for edge split modifier.