### PR TITLE
Auto activate and deactivate bone layers

### DIFF
--- a/io_export_cryblend/export_animations.py
+++ b/io_export_cryblend/export_animations.py
@@ -75,9 +75,11 @@ class CrytekDaeAnimationExporter(export.CrytekDaeExporter):
 
             if node_type in ALLOWED_NODE_TYPES:
                 object_ = None
+                layers = None
 
                 if node_type == 'i_caf':
                     object_ = utils.get_armature_from_node(group)
+                    layers = utils.activate_all_bone_layers(object_)
                 elif node_type == 'anm':
                     object_ = group.objects[0]
 
@@ -103,6 +105,7 @@ class CrytekDaeAnimationExporter(export.CrytekDaeExporter):
                 finally:
                     if node_type == 'i_caf':
                         utils.remove_fakebones()
+                        utils.recover_bone_layers(object_, layers)
 
                     cbPrint("Animation has been processed.")
 

--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -1240,6 +1240,20 @@ def get_armature_from_node(group):
     return None
 
 
+def activate_all_bone_layers(armature):
+    layers = []
+    for index in range(0, 32):
+        layers.append(armature.data.layers[index])
+        armature.data.layers[index] = True
+
+    return layers
+
+
+def recover_bone_layers(armature, layers):
+    for index in range(0, 32):
+        armature.data.layers[index] = layers[index]
+
+
 #------------------------------------------------------------------------------
 # General:
 #------------------------------------------------------------------------------


### PR DESCRIPTION
All bone layers, which have a bone, must be activated before exporting skeleton animation. That feature automate that process and reset them to initial state after exporting.

- Activate all bone layers before exporting.
- Reset bone layers state after exporting.

The error has been fixed, which was occurred when a bone layer inactive while exporting:
![error_01](https://cloud.githubusercontent.com/assets/12111733/17465628/6fa5ca8a-5d05-11e6-8d24-c358a93c5a55.jpg)
