### PR TITLE
Add Animation Node Range Type

### DIFF
--- a/io_export_cryblend/__init__.py
+++ b/io_export_cryblend/__init__.py
@@ -248,11 +248,44 @@ class AddCryAnimationNode(bpy.types.Operator):
         default="i_caf",
     )
     node_name = StringProperty(name="Animation Name")
+    range_type = EnumProperty(
+        name="Range Type",
+        items=(
+            ("Timeline", "Timeline Editor",
+             desc.list['range_timeline']),
+            ("Values", "Limit with Values",
+             desc.list['range_values']),
+            ("Markers", "Limit with Markers",
+             desc.list['range_markers']),
+        ),
+        default="Timeline",
+    ) 
     node_start = IntProperty(name="Start Frame")
     node_end = IntProperty(name="End Frame")
-    is_use_markers = BoolProperty(name="Use Markers")
     start_m_name = StringProperty(name="Marker Start Name")
     end_m_name = StringProperty(name="Marker End Name")
+
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        col.prop(self, "node_type")
+        col.prop(self, "node_name")
+        col.separator()
+        col.separator()
+
+        col.prop(self, "range_type", expand=True)
+        col.separator()
+        col.separator()
+
+        col.label("Animation Range Values:")
+        col.prop(self, "node_start")
+        col.prop(self, "node_end")
+        col.separator()
+        col.separator()
+
+        col.label("Animation Range Markers:")
+        col.prop(self, "start_m_name")
+        col.prop(self, "end_m_name")
 
     def __init__(self):
         self.node_start = bpy.context.scene.frame_start
@@ -288,7 +321,14 @@ class AddCryAnimationNode(bpy.types.Operator):
             start_name = "{}_Start".format(self.node_name)
             end_name = "{}_End".format(self.node_name)
 
-            if self.is_use_markers:
+            if self.range_type == 'Values':
+                node_start = self.node_start
+                node_end = self.node_end
+
+                object_[start_name] = node_start
+                object_[end_name] = node_end
+
+            elif self.range_type == 'Markers':
                 node_start = self.start_m_name
                 node_end = self.end_m_name
 
@@ -297,12 +337,9 @@ class AddCryAnimationNode(bpy.types.Operator):
                     tm.new(name=self.start_m_name, frame=self.node_start)
                 if tm.find(self.end_m_name) == -1:
                     tm.new(name=self.end_m_name, frame=self.node_end)
-            else:
-                node_start = self.node_start
-                node_end = self.node_end
 
-            object_[start_name] = node_start
-            object_[end_name] = node_end
+                object_[start_name] = node_start
+                object_[end_name] = node_end
 
             node_name = "{}.{}".format(self.node_name, self.node_type)
             group = bpy.data.groups.get(node_name)

--- a/io_export_cryblend/desc.py
+++ b/io_export_cryblend/desc.py
@@ -152,6 +152,22 @@ list['notaprim'] = """A general physics proxy parameter, it keeps the physics\
  mesh from being turned into a primitive (box, cylinder). This is\
  especially important for deformable objects - the skeleton being\
  a primitive will cause a crash!"""
+
+#------------------------------------------------------------------------------
+# Animation Range Types:
+#------------------------------------------------------------------------------
+
+list['range_timeline'] = """Animation range is set from Timeline Editor.\
+ You may directly change start and end frame from Timeline Editor. This is\
+ best choice for single animation per file."""
+
+list['range_values'] = """Animation range is stored in custom properties\
+ values. You must enter animation range values. You can change start or end
+ frame from object custom properties. This is ideal for multiple animations\
+ in a blender project."""
+
+list['range_markers'] = """Animation range is stored animation markers.\
+ Markers can directly be set on Timeline Editor to change frame range."""
  
 #------------------------------------------------------------------------------
 # Export:

--- a/io_export_cryblend/export_animations.py
+++ b/io_export_cryblend/export_animations.py
@@ -84,7 +84,7 @@ class CrytekDaeAnimationExporter(export.CrytekDaeExporter):
                     object_ = group.objects[0]
 
                 frame_start, frame_end = utils.get_animation_node_range(
-                    object_, node_name)
+                    object_, node_name, initial_frame_start, initial_frame_end)
                 bpy.context.scene.frame_start = frame_start
                 bpy.context.scene.frame_end = frame_end
 

--- a/io_export_cryblend/utils.py
+++ b/io_export_cryblend/utils.py
@@ -1201,7 +1201,7 @@ def get_bones(armature):
     return [bone for bone in armature.data.bones]
 
 
-def get_animation_node_range(object_, node_name):
+def get_animation_node_range(object_, node_name, initial_start, initial_end):
     try:
         start_frame = object_["{}_Start".format(node_name)]
         end_frame = object_["{}_End".format(node_name)]
@@ -1215,7 +1215,7 @@ def get_animation_node_range(object_, node_name):
         else:
             return start_frame, end_frame
     except:
-        return bpy.context.scene.frame_start, bpy.context.scene.frame_end
+        return initial_start, initial_end
 
 
 def get_armature_from_node(group):


### PR DESCRIPTION
New enumerate has been added name as **range_type**

That serve three option to add animation:

**Timeline Editor:** Animation range is set from Timeline Editor.  You may directly change start and end frame from Timeline Editor. This is best choice for single animation per file.

**Limit with Values:** Animation range is stored in custom properties values. You must enter animation range values. You can change start or end frame from object custom properties. This is ideal for multiple animations in a blender project.

**Limit with Markers:** Animation range is stored animation markers. Markers can directly be set on Timeline Editor to change frame range.

**Add Animation Node Menu:**
![add_animation_node_menu](https://cloud.githubusercontent.com/assets/12111733/17595692/af90cb42-5ff6-11e6-98fe-1591fdac191b.jpg)
